### PR TITLE
Add Rails 5.1 & 5.2 support & drop Rails 4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: ruby
 rvm:
-  - 2.2.4
+  - 2.5
+  - 2.6
+  - 2.7
 env:
-  - 'RAILS_VERSION="4.2" AMS_VERSION="0.10.0.rc5"'
-  - 'RAILS_VERSION="master" AMS_VERSION="0.10.0.rc5"'
-  - 'RAILS_VERSION="4.2" AMS_BRANCH=master'
-  - 'RAILS_VERSION="master" AMS_BRANCH=master'
+  - 'RAILS_VERSION="5.1" AMS_VERSION="0.10.7"'
+  - 'RAILS_VERSION="5.2" AMS_VERSION="0.10.12"'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+## [0.0.12.0](https://github.com/bmorrall/fun_with_json_api/compare/v0.0.11.3...v0.0.12.0) - 2021-04-09
+
+- Drop Rails 4 support
+- Add rails 5.1 & 5.2 support [#2518](https://github.com/bmorrall/fun_with_json_api/pull/3)

--- a/Gemfile
+++ b/Gemfile
@@ -12,7 +12,7 @@ gemspec
 
 gem 'rake', '< 11.0'
 
-rails_version = ENV['RAILS_VERSION'] || '4.2'
+rails_version = ENV['RAILS_VERSION'] || '5.2'
 if rails_version == 'master'
   gem 'rails', github: 'rails/rails'
 else
@@ -23,7 +23,7 @@ end
 if (ams_version = ENV['AMS_VERSION'])
   gem 'active_model_serializers', "= #{ams_version}"
 elsif (ams_branch = ENV.fetch('AMS_BRANCH', 'master'))
-  gem 'active_model_serializers', github: 'rails-api/active_model_serializers',
+  gem 'active_model_serializers', git: 'https://github.com/rails-api/active_model_serializers.git',
                                   branch: ams_branch
 end
 

--- a/fun_with_json_api.gemspec
+++ b/fun_with_json_api.gemspec
@@ -18,13 +18,12 @@ Gem::Specification.new do |s|
   s.files = Dir['{app,config,db,lib}/**/*', 'MIT-LICENSE', 'Rakefile', 'README.rdoc']
   s.test_files = Dir['spec/**/*']
 
-  s.add_dependency 'rails', '>= 4.2'
-  s.add_dependency 'active_model_serializers', '>= 0.10.0.rc4'
+  s.add_dependency 'rails', '>= 5.2'
+  s.add_dependency 'active_model_serializers', '>= 0.10.0'
 
-  s.add_development_dependency 'sqlite3'
+  s.add_development_dependency 'sqlite3', '~> 1.3.6'
   s.add_development_dependency 'rspec-rails'
   s.add_development_dependency 'faker'
-  s.add_development_dependency 'factory_girl_rails'
   s.add_development_dependency 'rubocop', '~> 0.38.0'
   s.add_development_dependency 'rubocop-rspec'
   s.add_development_dependency 'simplecov'

--- a/lib/fun_with_json_api/middleware/catch_json_api_parse_errors.rb
+++ b/lib/fun_with_json_api/middleware/catch_json_api_parse_errors.rb
@@ -9,7 +9,7 @@ module FunWithJsonApi
 
       def call(env)
         @app.call(env)
-      rescue ActionDispatch::ParamsParser::ParseError => error
+      rescue ActionDispatch::Http::Parameters::ParseError => error
         if env['CONTENT_TYPE'] =~ JSON_API_REGEX && respond_with_json_api_error?(env)
           build_json_api_parse_error_response
         else

--- a/lib/fun_with_json_api/railtie.rb
+++ b/lib/fun_with_json_api/railtie.rb
@@ -24,16 +24,10 @@ module FunWithJsonApi
       end
 
       # Add Middleware for catching parser errors
-      if Rails::VERSION::MAJOR >= 5
-        ActionDispatch::Request.parameter_parsers = parsers::DEFAULT_PARSERS
-        app.config.middleware.use(
-          'FunWithJsonApi::Middleware::CatchJsonApiParseErrors'
-        )
-      else
-        app.config.middleware.insert_before(
-          parsers, 'FunWithJsonApi::Middleware::CatchJsonApiParseErrors'
-        )
-      end
+      ActionDispatch::Request.parameter_parsers = parsers::DEFAULT_PARSERS
+      app.config.middleware.use(
+        FunWithJsonApi::Middleware::CatchJsonApiParseErrors
+      )
     end
     initializer :register_json_api_renderer do
       ActionController::Renderers.add :json_api do |json, options|

--- a/lib/fun_with_json_api/version.rb
+++ b/lib/fun_with_json_api/version.rb
@@ -1,3 +1,3 @@
 module FunWithJsonApi
-  VERSION = '0.0.11.3'.freeze
+  VERSION = '0.0.12.0'.freeze
 end

--- a/spec/dummy/app/controllers/application_controller.rb
+++ b/spec/dummy/app/controllers/application_controller.rb
@@ -10,4 +10,8 @@ class ApplicationController < ActionController::Base
   def echo
     render json: params.slice(:data)
   end
+
+  def blah
+    puts ">>>> #{params.inspect}"
+  end
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -44,4 +44,7 @@ Rails.application.configure do
 
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
+
+  #config.logger = Logger.new(STDOUT)
+
 end

--- a/spec/fun_with_json_api/railtie_spec.rb
+++ b/spec/fun_with_json_api/railtie_spec.rb
@@ -6,16 +6,15 @@ describe FunWithJsonApi::Railtie do
       controller do
         def index
           # Concatinates /data/id and /data/type from a json_api request
-          render text: "#{params[:data][:id]}:#{params['data']['type']}"
+          render plain: "#{params[:data][:id]}:#{params['data']['type']}"
         end
       end
 
       it 'converts the request body into param values' do
         json_api_data = { data: { id: '42', type: 'foobar' } }
 
-        get :index,
-            json_api_data.as_json,
-            'Content-Type' => 'application/vnd.api+json'
+        request.headers['Content-Type'] = 'application/vnd.api+json'
+        get :index, params: json_api_data.as_json
         expect(response.body).to eq '42:foobar'
       end
     end
@@ -34,7 +33,7 @@ describe FunWithJsonApi::Railtie do
         expect(response.body).to eq 'passed'
       end
       it 'responds to a application/vnd.api+json accept header' do
-        request.env['HTTP_ACCEPT'] = 'application/vnd.api+json'
+        request.headers['HTTP_ACCEPT'] = 'application/vnd.api+json'
         get :index
         expect(response.body).to eq 'passed'
       end

--- a/spec/requests/request_parsing_spec.rb
+++ b/spec/requests/request_parsing_spec.rb
@@ -4,8 +4,13 @@ describe 'Request Parsing', type: :request do
   it 'converts a json_api request body into param values' do
     request_data = '{"data":{"id":"42","type":"foobar"}}'
 
-    post '/echo', request_data, 'Accept': 'application/vnd.api+json',
-                                'Content-Type': 'application/vnd.api+json'
+    post '/echo',
+      params: request_data,
+      headers: {
+        'Accept': 'application/vnd.api+json',
+        'Content-Type': 'application/vnd.api+json'
+      }
+
     expect(
       JSON.parse(response.body, symbolize_names: true)
     ).to eq(data: { id: '42', type: 'foobar' })
@@ -24,9 +29,11 @@ describe 'Request Parsing', type: :request do
       context 'when the request has a json api accept header' do
         it 'renders a json api invalid document response' do
           post '/echo',
-               invalid_request_data,
-               'Accept': 'application/vnd.api+json',
-               'Content-Type': 'application/vnd.api+json'
+            params: invalid_request_data,
+            headers: {
+              'Accept': 'application/vnd.api+json',
+              'Content-Type': 'application/vnd.api+json'
+            }
 
           expect(response.status).to eq 400
           expect(JSON.parse(response.body, symbolize_names: true)).to eq(
@@ -41,9 +48,11 @@ describe 'Request Parsing', type: :request do
       context 'when the request has a json api accept header with utf-8 charset' do
         it 'renders a json api invalid document response' do
           post '/echo',
-               invalid_request_data,
-               'Accept': 'application/vnd.api+json; charset=utf-8',
-               'Content-Type': 'application/vnd.api+json; charset=utf-8'
+            params: invalid_request_data,
+            headers: {
+              'Accept': 'application/vnd.api+json; charset=utf-8',
+              'Content-Type': 'application/vnd.api+json; charset=utf-8'
+            }
 
           expect(response.status).to eq 400
           expect(JSON.parse(response.body, symbolize_names: true)).to eq(
@@ -59,7 +68,7 @@ describe 'Request Parsing', type: :request do
         it 'renders a json api invalid document response' do
           invalid_request_data = '{"data":{"id":"42","type":"foobar",}}' # extra comma
 
-          post '/echo', invalid_request_data, 'Content-Type': 'application/vnd.api+json'
+          post '/echo', params: invalid_request_data, headers: { 'Content-Type': 'application/vnd.api+json' }
 
           expect(response.status).to eq 400
         end
@@ -76,9 +85,11 @@ describe 'Request Parsing', type: :request do
       context 'when the request has a json api accept header' do
         it 'renders a json api invalid document response' do
           post '/echo',
-               invalid_request_data,
-               'Accept': 'application/vnd.api+json',
-               'Content-Type': 'application/vnd.api+json'
+            params: invalid_request_data,
+            headers: {
+              'Accept': 'application/vnd.api+json',
+              'Content-Type': 'application/vnd.api+json'
+            }
 
           expect(response.status).to eq 400
         end
@@ -87,8 +98,8 @@ describe 'Request Parsing', type: :request do
       context 'when the request does not have a json api accept header' do
         it 'raises a ActionDispatch::ParamsParser::ParseError' do
           expect do
-            post '/echo', invalid_request_data, 'Content-Type': 'application/vnd.api+json'
-          end.to raise_error(ActionDispatch::ParamsParser::ParseError)
+            post '/echo', params: invalid_request_data, headers: { 'Content-Type': 'application/vnd.api+json' }
+          end.to raise_error(ActionDispatch::Http::Parameters::ParseError)
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -18,7 +18,6 @@ require 'fun_with_json_api'
 require 'fixtures/active_record'
 require 'rspec/rails'
 require 'faker'
-require 'factory_girl_rails'
 
 Rails.backtrace_cleaner.remove_silencers!
 


### PR DESCRIPTION
Helloes :)

## Changes
* Add Rails 5.1 & 5.2 support
  - Adding middleware as a string [was deprecated](https://guides.rubyonrails.org/5_0_release_notes.html#action-pack-deprecations)
  - `ParseError` has a new home
* Drop Rails 4.x support
  It's not supported anymore